### PR TITLE
Fix README output copy for 2.6 section

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ There is also the opposite for asking confirmation of negative option:
 ```ruby
 prompt.no?('Do you hate Ruby?')
 # =>
-# Do you like Ruby? (y/N)
+# Do you hate Ruby? (y/N)
 ```
 
 ### 2.7 select


### PR DESCRIPTION
I'd like to start off thanking you for all your work on this beautiful gem:
well written, documented and readable code that provides a sweet API.
:bow: :bow: :bow:

I've noticed a tiny mistake on the wording for a snippet output in section
`2.6 yes?/no?`. It reads `like` instead of `hate` as it is in the input code.

That's pretty much it. I haven't spotted anything wrong anywhere else in
the docs or the code. :smile: 

Again, thank you for your work!